### PR TITLE
update metadata to reflect that this is a package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dynamic = ["dependencies", "optional-dependencies"]
 [tool.setuptools]
 # TODO: IF LIBRARY FILES ARE A PACKAGE FOLDER,
 #       CHANGE `py_modules = ['...']` TO `packages = ['...']`
-py-modules = ["cedargrove_airqualitytools"]
+packages = ["cedargrove_airqualitytools"]
 
 [tool.setuptools.dynamic]
 dependencies = {file = ["requirements.txt"]}


### PR DESCRIPTION
The package metadata needs to be correct, so that we can make the bundle builder rely on it: https://github.com/adafruit/circuitpython-build-tools/pull/101

Please tag a new release of this library after accepting this PR. If you don't think you'll be able to do this in a timely fashion let us know and we'll figure out how to handle it; this problem does block accepting that PR, which in turn blocks some things we want to do.